### PR TITLE
Changed the call to setlinebuf for setvbuf

### DIFF
--- a/logging.c
+++ b/logging.c
@@ -103,7 +103,7 @@ kutil_openlog(const char *file)
 
 	if (NULL != file && NULL == freopen(file, "a", stderr))
 		return(0);
-	return(EOF != setlinebuf(stderr));
+	return (EOF != setvbuf(stderr, NULL, _IOLBF, 1000));
 }
 
 void


### PR DESCRIPTION
As setlinebuf has type void and setvbuf has type int.
This fixed the following compile error for me:
logging.c:106:2: error: void value not ignored as it ought to be