### PR TITLE
Improve khttp_parse.3

### DIFF
--- a/man/khttp_parse.3
+++ b/man/khttp_parse.3
@@ -42,7 +42,7 @@
 .Fa "struct kreq *req"
 .Fa "const struct kmimemap *suffixes"
 .Fa "const char *const *mimes"
-.Fa "size_t mimemax"
+.Fa "size_t mimesz"
 .Fa "const struct kvalid *keys"
 .Fa "size_t keysz"
 .Fa "const char *const *pages"
@@ -128,8 +128,10 @@ An array of input and validation fields.
 .It Fa keysz
 The number of elements in
 .Fa keys .
-.It Fa mimemax
-The MIME index used if no MIME type was matched.
+.It Fa mimesz
+The number of elements in
+.Fa mimes .
+Also the MIME index used if no MIME type was matched.
 This differs from
 .Fa defmime ,
 which is used if there is no MIME suffix at all.
@@ -313,7 +315,7 @@ or the default
 if using
 .Fn khttp_parse .
 This defaults to the
-.Va mimemax
+.Va mimesz
 value passed to
 .Fn khttp_parsex
 or the default


### PR DESCRIPTION
Replace mimemax with mimesz, making it more consistent with the
other parameter names, pagesz and keysz.