### PR TITLE
Return and propagate kworker_child errors

### DIFF
--- a/afl/afl-multipart.c
+++ b/afl/afl-multipart.c
@@ -35,6 +35,7 @@ int
 main(int argc, char *argv[])
 {
 	int	 	 fdout, fdin;
+	enum kcgi_err	 kerr;
 	struct stat	 st;
 	char		 buf[1024];
 
@@ -71,8 +72,8 @@ main(int argc, char *argv[])
 		"boundary=---------------------------9051914041544843365972754266", 1);
 	setenv("REQUEST_METHOD", "post", 1);
 	setenv("CONTENT_LENGTH", buf, 1);
-	kworker_child(fdout, NULL, 0, kmimetypes, KMIME__MAX, 0);
+	kerr = kworker_child(fdout, NULL, 0, kmimetypes, KMIME__MAX, 0);
 	close(fdin);
 	close(fdout);
-	return(EXIT_SUCCESS);
+	return(KCGI_OK == kerr ? EXIT_SUCCESS : EXIT_FAILURE);
 }

--- a/afl/afl-plain.c
+++ b/afl/afl-plain.c
@@ -35,6 +35,7 @@ int
 main(int argc, char *argv[])
 {
 	int	 	 fdout, fdin;
+	enum kcgi_err	 kerr;
 	struct stat	 st;
 	char		 buf[1024];
 
@@ -70,8 +71,8 @@ main(int argc, char *argv[])
 	setenv("CONTENT_TYPE", "text/plain", 1);
 	setenv("REQUEST_METHOD", "post", 1);
 	setenv("CONTENT_LENGTH", buf, 1);
-	kworker_child(fdout, NULL, 0, kmimetypes, KMIME__MAX, 0);
+	kerr = kworker_child(fdout, NULL, 0, kmimetypes, KMIME__MAX, 0);
 	close(fdin);
 	close(fdout);
-	return(EXIT_SUCCESS);
+	return(KCGI_OK == kerr ? EXIT_SUCCESS : EXIT_FAILURE);
 }

--- a/afl/afl-urlencoded.c
+++ b/afl/afl-urlencoded.c
@@ -35,6 +35,7 @@ int
 main(int argc, char *argv[])
 {
 	int	 	 fdout, fdin;
+	enum kcgi_err	 kerr;
 	struct stat	 st;
 	char		 buf[1024];
 
@@ -70,8 +71,8 @@ main(int argc, char *argv[])
 	setenv("CONTENT_TYPE", "application/x-www-form-urlencoded", 1);
 	setenv("REQUEST_METHOD", "post", 1);
 	setenv("CONTENT_LENGTH", buf, 1);
-	kworker_child(fdout, NULL, 0, kmimetypes, KMIME__MAX, 0);
+	kerr = kworker_child(fdout, NULL, 0, kmimetypes, KMIME__MAX, 0);
 	close(fdin);
 	close(fdout);
-	return(EXIT_SUCCESS);
+	return(KCGI_OK == kerr ? EXIT_SUCCESS : EXIT_FAILURE);
 }

--- a/child.c
+++ b/child.c
@@ -1319,7 +1319,7 @@ kworker_child_last(int fd)
  * value size along with the field type.
  * We use the CGI specification in RFC 3875.
  */
-void
+enum kcgi_err
 kworker_child(int sock,
 	const struct kvalid *keys, size_t keysz, 
 	const char *const *mimes, size_t mimesz,
@@ -1348,7 +1348,7 @@ kworker_child(int sock,
 		envsz++;
 	envs = XCALLOC(envsz, sizeof(struct env));
 	if (NULL == envs)
-		return;
+		return KCGI_ENOMEM;
 	/*
 	 * While pulling in the environment, look for HTTP headers
 	 * (those beginning with HTTP_).
@@ -1394,6 +1394,7 @@ kworker_child(int sock,
 	for (i = 0; i < envsz; i++) 
 		free(envs[i].key);
 	free(envs);
+	return KCGI_OK;
 }
 
 /*

--- a/extern.h
+++ b/extern.h
@@ -49,7 +49,7 @@ void		 kdata_free(struct kdata *, int);
 
 int		 kworker_auth_child(int, const char *);
 enum kcgi_err	 kworker_auth_parent(int, struct khttpauth *);
-void	 	 kworker_child(int,
+enum kcgi_err	 kworker_child(int,
 			const struct kvalid *, size_t, 
 			const char *const *, size_t,
 			unsigned int);

--- a/kcgi.c
+++ b/kcgi.c
@@ -660,17 +660,18 @@ khttp_parsex(struct kreq *req,
 			(*argfree)(arg);
 		close(STDOUT_FILENO);
 		close(work_dat[KWORKER_PARENT]);
+		er = EXIT_FAILURE;
 		if ( ! ksandbox_init_child
 			(work_box, SAND_WORKER,
 			 work_dat[KWORKER_CHILD], -1, -1, -1)) {
 			XWARNX("ksandbox_init_child");
-			er = EXIT_FAILURE;
-		} else {
-			kworker_child(work_dat[KWORKER_CHILD], 
-				keys, keysz, mimes, mimesz,
-				debugging);
+		} else if (KCGI_OK != kworker_child
+					(work_dat[KWORKER_CHILD], keys,
+					keysz, mimes, mimesz,
+					debugging)) {
+			XWARNX("kworker_child");
+		} else
 			er = EXIT_SUCCESS;
-		}
 		ksandbox_free(work_box);
 		close(work_dat[KWORKER_CHILD]);
 		_exit(er);


### PR DESCRIPTION
Add error return value to kworker_child and report out-of-memory
condition.
