### PR TITLE
Fixed some compiler warnings

### DIFF
--- a/auth.c
+++ b/auth.c
@@ -169,7 +169,7 @@ khttpdigest_validatehash(const struct kreq *req, const char *skey4)
 
 	if (KHTTPQOP_AUTH_INT == auth->qop || 
 	    KHTTPQOP_AUTH == auth->qop) {
-		snprintf(count, sizeof(count), "%08lx", auth->count);
+		snprintf(count, sizeof(count), "%08zx", auth->count);
 		MD5Init(&ctx);
 		MD5Update(&ctx, skey1, MD5_DIGEST_LENGTH * 2);
 		MD5Update(&ctx, ":", 1);

--- a/kcgi.c
+++ b/kcgi.c
@@ -1207,7 +1207,7 @@ khttp_templatex(const struct ktemplate *t,
 		XWARN("fstat: %s", fname);
 		close(fd);
 		return(0);
-	} else if (st.st_size >= (1U << 31)) {
+	} else if ((unsigned long int)st.st_size >= (1U << 31)) {
 		XWARNX("size overflow: %s", fname);
 		close(fd);
 		return(0);


### PR DESCRIPTION
I understand the printf formats "%zu", "%zx", etc. are part of C99. I don't know if that's an issue for this project. Alternatively, that warning could be handled with:

snprintf(count, sizeof(count), "%08lx", (long unsigned int)auth->count);