### PR TITLE
Handle nonce-count as hexadecimal in kauth_count (resolve #41)

### DIFF
--- a/regress/test-digest-auth-int.c
+++ b/regress/test-digest-auth-int.c
@@ -44,9 +44,9 @@ parent(CURL *curl)
 		"nonce=\"367sj3265s5\","
 		"uri=\"/plain.txt\","
 		"qop=auth-int,"
-		"nc=00000001,"
+		"nc=000001ff,"
 		"cnonce=\"hxk1lu63b6c7vhk\","
-		"response=\"5ab6822b9d906cc711760a7783b28dca\","
+		"response=\"517a8a2617faed1847835f3ec271ca38\","
 		"opaque=\"87aaxcval4gba36\"");
 	list = curl_slist_append(list,
 		"Content-Type: application/octet-stream");


### PR DESCRIPTION
This attempts to resolve #41 and modifies the digest-auth-int-testcase to use a value greater than 9.