### PR TITLE
Add kutil_urldecode()

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -155,6 +155,7 @@ REGRESS		 = regress/test-basic \
 		   regress/test-template \
 		   regress/test-upload \
 		   regress/test-urlencode \
+		   regress/test-urldecode \
 		   regress/test-urlpart \
 		   regress/test-valid-date \
 		   regress/test-valid-double

--- a/kcgi.c
+++ b/kcgi.c
@@ -440,6 +440,54 @@ kutil_urlencode(const char *cp)
 	return(p);
 }
 
+/*
+ * In-place HTTP-decode a string.  The standard explanation is that this
+ * turns "%4e+foo" into "n foo" in the regular way.  This is done
+ * in-place over the allocated string.
+ * Returns KCGI_FORM on decoding failure, KCGI_OK otherwise.
+ */
+enum kcgi_err
+kutil_urldecode_inplace(char *p)
+{
+	char		 hex[3];
+	unsigned int	 c;
+
+	hex[2] = '\0';
+
+	for ( ; '\0' != *p; p++) {
+		if ('%' == *p) {
+			if ('\0' == (hex[0] = *(p + 1))) {
+				XWARNX("urldecode: short hex");
+				return(KCGI_FORM);
+			} else if ('\0' == (hex[1] = *(p + 2))) {
+				XWARNX("urldecode: short hex");
+				return(KCGI_FORM);
+			} else if (1 != sscanf(hex, "%x", &c)) {
+				XWARNX("urldecode: bad hex");
+				return(KCGI_FORM);
+			} else if ('\0' == c) {
+				XWARNX("urldecode: NUL byte");
+				return(KCGI_FORM);
+			}
+
+			*p = c;
+			memmove(p + 1, p + 3, strlen(p + 3) + 1);
+		} else if ('+' == *p)
+			*p = ' ';
+	}
+
+	return(KCGI_OK);
+}
+
+enum kcgi_err
+kutil_urldecode(const char *src, char **dst)
+{
+	if (NULL == (*dst = strdup(src))) {
+		return(KCGI_ENOMEM);
+	}
+	return(kutil_urldecode_inplace(*dst));
+}
+
 char *
 kutil_urlabs(enum kscheme scheme, 
 	const char *host, uint16_t port, const char *path)

--- a/kcgi.h
+++ b/kcgi.h
@@ -616,6 +616,8 @@ char		*kutil_urlpart(struct kreq *, const char *,
 char		*kutil_urlpartx(struct kreq *, const char *,
 			const char *, const char *, ...);
 char		*kutil_urlencode(const char *);
+enum kcgi_err	 kutil_urldecode(const char *, char **);
+enum kcgi_err	 kutil_urldecode_inplace(char *);
 void		 kutil_invalidate(struct kreq *, struct kpair *);
 
 int		 kutil_openlog(const char *);

--- a/man/kutil_urlencode.3
+++ b/man/kutil_urlencode.3
@@ -23,6 +23,8 @@
 .Nm kutil_urlpart ,
 .Nm kutil_urlpartx ,
 .Nm kutil_urlencode
+.Nm kutil_urldecode
+.Nm kutil_urldecode_inplace
 .Nd URL formatting for kcgi
 .Sh LIBRARY
 .Lb libkcgi
@@ -56,6 +58,13 @@
 .Fc
 .Ft "char *"
 .Fn kutil_urlencode "const char *cp"
+.Ft "enum kcgi_err"
+.Fo kutil_urldecode
+.Fa "const char *src"
+.Fa "char **dst"
+.Fc
+.Ft "enum kcgi_err"
+.Fn kutil_urldecode_inplace "char *cp"
 .Sh DESCRIPTION
 These functions format various parts of a URL.
 .Pp
@@ -134,6 +143,17 @@ The
 function encodes a string for embedding in a URL.
 .Pp
 The
+.Fn kutil_urldecode
+function decodes the given string
+.Fa src
+and stores the result in the newly allocated string
+.Fa *dst .
+.Pp
+The
+.Fn kutil_urldecode_inplace
+function decodes the given string in-place.
+.Pp
+The
 .Fn kutil_urlabs
 function assembles the URL
 .Fa schema Ns :// Ns Fa host : Ns Fa port Ns Fa path .
@@ -147,7 +167,13 @@ or just
 .Fn kutil_urlencode
 for the sensitive parts.
 .Sh RETURN VALUES
-These functions return newly-allocated strings that must be freed with
+The
+.Fn kutil_urlabs ,
+.Fn kutil_urlpart ,
+.Fn kutil_urlpartx
+and
+.Fn kutil_urlencode
+functions return newly-allocated strings that must be freed with
 .Xr free 3 .
 They return
 .Dv NULL
@@ -160,6 +186,21 @@ if
 .Fa cp
 is
 .Dv NULL .
+.Pp
+Additionally the
+.Fn kutil_urldecode
+and
+.Fn kutil_urldecode_inplace
+functions returns an error code:
+.Bl -tag -width -Ds
+.It Dv KCGI_OK
+Success (not an error).
+.It Dv KCGI_ENOMEM
+Memory failure, only
+.Fn kutil_urldecode .
+.It Dv KCGI_FORM
+Malformed input data.
+.El
 .Sh AUTHORS
 These functions were written by
 .An Kristaps Dzonsons Aq Mt kristaps@bsd.lv .

--- a/regress/test-urldecode.c
+++ b/regress/test-urldecode.c
@@ -1,0 +1,83 @@
+/*	$Id$ */
+/*
+ * Copyright (c) 2018 Kristaps Dzonsons <kristaps@bsd.lv>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+#include "../config.h"
+
+#if HAVE_ERR
+# include <err.h>
+#endif
+
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "../kcgi.h"
+
+struct	test {
+	enum kcgi_err	 errorcode;
+	const char	*input;
+	const char	*output;
+};
+
+static	const struct test tests[] = {
+	{ KCGI_OK, "", "" },
+	{ KCGI_OK, "foobar", "foobar" },
+	{ KCGI_OK, "foo+bar", "foo bar" },
+	{ KCGI_OK, "foo~bar", "foo~bar" },
+	{ KCGI_OK, "foo-bar", "foo-bar" },
+	{ KCGI_OK, "foo_bar", "foo_bar" },
+	{ KCGI_OK, "foo.bar", "foo.bar" },
+	{ KCGI_OK, "foo.bar.", "foo.bar." },
+	{ KCGI_OK, "foo.bar.-", "foo.bar.-" },
+	{ KCGI_OK, "-_foo.bar.-", "-_foo.bar.-" },
+	{ KCGI_OK, "-_foo%2bbar.-", "-_foo+bar.-" },
+	{ KCGI_OK, "-_foo%09bar.-", "-_foo\tbar.-" },
+	{ KCGI_OK, "%09-_foo%09bar.-", "\t-_foo\tbar.-" },
+	{ KCGI_OK, "%09-_foo%09bar.-%09", "\t-_foo\tbar.-\t" },
+	{ KCGI_OK, "%09-_foo%25%09bar.-%09", "\t-_foo%\tbar.-\t" },
+	{ KCGI_OK, "-_foo%2509%7dbar.-", "-_foo%09}bar.-" },
+	{ KCGI_OK, "%09%09%09%09", "\t\t\t\t" },
+	{ KCGI_FORM, "foo%zubar", "foo%zubar" },
+	{ KCGI_FORM, "foo%", "foo%" },
+	{ KCGI_OK, NULL, NULL }
+};
+
+int
+main(int argc, char *argv[])
+{
+	const struct test *t;
+	char	*url;
+	enum kcgi_err code;
+
+	url = NULL;
+	for (t = tests; NULL != t->input; t++) {
+		code = kutil_urldecode(t->input, &url);
+		if (KCGI_ENOMEM == code)
+			return(EXIT_FAILURE);
+		if (t->errorcode != code)
+			errx(EXIT_FAILURE, "%s: fail (returned %i, "
+				"wanted %i)", t->input, code, t->errorcode);
+		if (strcmp(url, t->output))
+			errx(EXIT_FAILURE, "%s: fail (have %s, "
+				"want %s)", t->input, url, t->output);
+		free(url);
+	}
+
+	return(EXIT_SUCCESS);
+}


### PR DESCRIPTION
As expected this function does the inverse of kutil_urlencode().

I added the short documentation for this function in `kutil_urlencode.3` and recycled the regress tests in `test-urlencode.c`, with an additional one for invalid triplets like %zu which are not base 16 integers. I use this function in a kcgi-based project where I need to work with url-encoded strings and thought it could be useful for others too.

What do you think ?