### PR TITLE
Fix regress tests for libcurl>7.66.0

### DIFF
--- a/regress/test-fcgi-abort-validator.c
+++ b/regress/test-fcgi-abort-validator.c
@@ -30,6 +30,7 @@ static int
 parent(CURL *curl)
 {
 
+	curl_easy_setopt(curl, CURLOPT_HTTP09_ALLOWED, 1L);
 	curl_easy_setopt(curl, CURLOPT_URL, 
 		"http://localhost:17123/index.html?foo=bar");
 	return CURLE_GOT_NOTHING == curl_easy_perform(curl);

--- a/regress/test-fcgi-bigfile.c
+++ b/regress/test-fcgi-bigfile.c
@@ -48,6 +48,7 @@ parent(CURL *curl)
 	p[1024 * 1024 + 4] = '\0';
 
 	i = 0;
+	curl_easy_setopt(curl, CURLOPT_HTTP09_ALLOWED, 1L);
 	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, doign);
 	curl_easy_setopt(curl, CURLOPT_WRITEDATA, &i);
 	curl_easy_setopt(curl, CURLOPT_POSTFIELDS, p);

--- a/regress/test-fcgi-file-get.c
+++ b/regress/test-fcgi-file-get.c
@@ -30,6 +30,7 @@ static int
 parent(CURL *curl)
 {
 
+	curl_easy_setopt(curl, CURLOPT_HTTP09_ALLOWED, 1L);
 	curl_easy_setopt(curl, CURLOPT_URL, 
 		"http://localhost:17123/test.html");
 	return(CURLE_OK == curl_easy_perform(curl));

--- a/regress/test-fcgi-header-bad.c
+++ b/regress/test-fcgi-header-bad.c
@@ -37,6 +37,7 @@ parent(CURL *curl)
 	slist = curl_slist_append(slist, "Testing\tfoo:123");
 	slist = curl_slist_append(slist, "Testing-Test:321");
 	slist = curl_slist_append(slist, "Test\bing-Test:321");
+	curl_easy_setopt(curl, CURLOPT_HTTP09_ALLOWED, 1L);
 	curl_easy_setopt(curl, CURLOPT_URL, "http://localhost:17123/");
 	curl_easy_setopt(curl, CURLOPT_HTTPHEADER, slist);
 	ret = curl_easy_perform(curl);

--- a/regress/test-fcgi-header.c
+++ b/regress/test-fcgi-header.c
@@ -36,6 +36,7 @@ parent(CURL *curl)
 	slist = NULL;
 	slist = curl_slist_append(slist, "Testing:123");
 	slist = curl_slist_append(slist, "Testing-Test:321");
+	curl_easy_setopt(curl, CURLOPT_HTTP09_ALLOWED, 1L);
 	curl_easy_setopt(curl, CURLOPT_URL, "http://localhost:17123/");
 	curl_easy_setopt(curl, CURLOPT_HTTPHEADER, slist);
 	ret = curl_easy_perform(curl);

--- a/regress/test-fcgi-path-check.c
+++ b/regress/test-fcgi-path-check.c
@@ -31,6 +31,7 @@ static int
 parent(CURL *curl)
 {
 
+	curl_easy_setopt(curl, CURLOPT_HTTP09_ALLOWED, 1L);
 	curl_easy_setopt(curl, CURLOPT_URL, 
 		"http://localhost:17123/test/foo/bar/baz.xml");
 	return(CURLE_OK == curl_easy_perform(curl));

--- a/regress/test-fcgi-ping-double.c
+++ b/regress/test-fcgi-ping-double.c
@@ -30,6 +30,7 @@ static int
 parent1(CURL *curl)
 {
 
+	curl_easy_setopt(curl, CURLOPT_HTTP09_ALLOWED, 1L);
 	curl_easy_setopt(curl, CURLOPT_URL, 
 		"http://localhost:17123/index1.html");
 	return CURLE_OK == curl_easy_perform(curl);
@@ -39,6 +40,7 @@ static int
 parent2(CURL *curl)
 {
 
+	curl_easy_setopt(curl, CURLOPT_HTTP09_ALLOWED, 1L);
 	curl_easy_setopt(curl, CURLOPT_URL, 
 		"http://localhost:17123/index2.html");
 	return CURLE_OK == curl_easy_perform(curl);

--- a/regress/test-fcgi-ping.c
+++ b/regress/test-fcgi-ping.c
@@ -30,6 +30,7 @@ static int
 parent(CURL *curl)
 {
 
+	curl_easy_setopt(curl, CURLOPT_HTTP09_ALLOWED, 1L);
 	curl_easy_setopt(curl, CURLOPT_URL, 
 		"http://localhost:17123/");
 	return(CURLE_OK == curl_easy_perform(curl));

--- a/regress/test-fcgi-upload.c
+++ b/regress/test-fcgi-upload.c
@@ -117,6 +117,7 @@ parent(CURL *curl)
 		CURLFORM_FILECONTENT, "Makefile", CURLFORM_END);
 
 	/* Set the form info */
+	curl_easy_setopt(curl, CURLOPT_HTTP09_ALLOWED, 1L);
 	curl_easy_setopt(curl, CURLOPT_HTTPPOST, post);
 	curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 	curl_easy_setopt(curl, CURLOPT_URL, 

--- a/regress/test-upload.c
+++ b/regress/test-upload.c
@@ -117,6 +117,7 @@ parent(CURL *curl)
 		CURLFORM_FILECONTENT, "Makefile", CURLFORM_END);
 
 	/* Set the form info */
+	curl_easy_setopt(curl, CURLOPT_HTTP09_ALLOWED, 1L);
 	curl_easy_setopt(curl, CURLOPT_HTTPPOST, post);
 	curl_easy_setopt(curl, CURLOPT_URL, 
 		"http://localhost:17123/");


### PR DESCRIPTION
### This is a bad solution, [it fixes the issue but the issue should be fixed differently.](https://github.com/kristapsdz/kcgi/issues/72#issuecomment-544187885)

Hey,

Since [curl 7.66.0 (released September 11 2019)](https://curl.haxx.se/changes.html#7_66_0):

> - http09: disable HTTP/0.9 by default in both tool and library

This makes several tests fail, with libcurl verbose option activated we can see that HTTP/0.9 is the issue.
```
* Received HTTP/0.9 when not allowed

* Closing connection 0
write: Connection reset by peer
wrappers.c:289: poll: POLLHUP
wrappers.c:289: poll: POLLHUP
wrappers.c:289: poll: POLLHUP
````

These changes are just adding the right option to all the tests that were failing.
Another option would be to not use HTTP/0.9, i'm not the one that will make that call.

This fixes #72 the issue came up on Arch Linux due to it being upgraded frequently but i'll arise on others distros/OS as soon as they update curl. Actually obsd's last release is affected.
I've tried building theses changes with an old libcurl version on Debian too to check if it did not break something, it also builds fine on armv6.

Note that i did not ask myself why those were HTTP/0.9, kcgi's manual states that 
>      +o	 HTTP response headers are standardised in RFC 2616, "HTTP/1.1"	and further in RFC 4229, "HTTP Header Field Registrations".

So maybe those shouldn't be HTTP/0.9 in the first place ?

Have a good day!