### PR TITLE
Port to work on linux aarch64 where regression tests pass

### DIFF
--- a/configure
+++ b/configure
@@ -444,6 +444,9 @@ if [ ${HAVE_SECCOMP_FILTER} -eq 1 ]; then
 		arm*)
 			echo "#define SECCOMP_AUDIT_ARCH AUDIT_ARCH_ARM"
 			;;
+		aarch64)
+			echo "#define SECCOMP_AUDIT_ARCH AUDIT_ARCH_AARCH64"
+			;;
 	esac
 fi
 

--- a/sandbox-seccomp-filter.c
+++ b/sandbox-seccomp-filter.c
@@ -47,6 +47,10 @@
 #include <linux/seccomp.h>
 #include <elf.h>
 
+#ifdef AUDIT_ARCH_AARCH64
+#define __ARCH_WANT_SYSCALL_NO_AT
+#define __ARCH_WANT_SYSCALL_DEPRECATED
+#endif
 #include <asm/unistd.h>
 
 #include <errno.h>
@@ -114,6 +118,9 @@ static const struct sock_filter preauth_ctrl[] = {
 	SC_ALLOW(shutdown),
 #endif
 	SC_ALLOW(brk),
+#ifdef __NR_ppoll
+	SC_ALLOW(ppoll),
+#endif
 	SC_ALLOW(poll),
 #ifdef __NR__newselect
 	SC_ALLOW(_newselect),
@@ -174,6 +181,9 @@ static const struct sock_filter preauth_work[] = {
 	SC_ALLOW(shutdown),
 #endif
 	SC_ALLOW(brk),
+#ifdef __NR_ppoll
+	SC_ALLOW(ppoll),
+#endif
 	SC_ALLOW(poll),
 #ifdef __NR__newselect
 	SC_ALLOW(_newselect),


### PR DESCRIPTION
I have an nvidia tegra tx2 that uses linux that I've tested this on with the regression suite.

I also ported the build system to CMake.  I can provide a separate pull request to add a CMakeLists.txt file that supports linux and osx (and probably other unix platforms).  Works alongside the bmake system.  I have one version that uses bmake as an external build tool and another version that is native CMake and puts the regression suite in ctest.