### PR TITLE
Buffer log message before writing to stderr

### DIFF
--- a/kcgi.c
+++ b/kcgi.c
@@ -371,6 +371,20 @@ kasprintf(char **p, const char *fmt, ...)
 }
 
 /*
+ * Safe vasprintf(): don't return on exhaustion.
+ */
+int
+kvasprintf(char **p, const char *fmt, va_list ap)
+{
+	int	 len;
+
+	if ((len = XVASPRINTF(p, fmt, ap)) >= 0)
+		return(len);
+
+	exit(EXIT_FAILURE);
+}
+
+/*
  * Safe calloc(): don't return on exhaustion.
  */
 void *

--- a/kcgi.h
+++ b/kcgi.h
@@ -663,6 +663,8 @@ void		 kutil_errx(const struct kreq *,
 
 int		 kasprintf(char **, const char *, ...)
 			__attribute__((format(printf, 2, 3)));
+int		 kvasprintf(char **, const char *, va_list)
+			__attribute__((format(printf, 2, 0)));
 void		*kcalloc(size_t, size_t);
 void		*kmalloc(size_t);
 void		*krealloc(void *, size_t);


### PR DESCRIPTION
As discussed in #75.

This uses dynamic allocation for the log message, although it needs a couple of stabs at it because of the varargs (vasprintf(), then asprintf()).

I wouldn't say it's particularly pretty, but it fixes #75 and eliminates the fixed buffer and trusted lvl and ident inputs. The err string is still trusted, but it's only supplied by strerror, so should be OK.

I've fuzzed it by taking 8 kB+ input from /dev/urandom, and valgrind (at least on Linux) seems happy.