### PR TITLE
meta: use correct license for LICENSE.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 Copyright (c) 2012--2016, Kristaps Dzonsons <kristaps@bsd.lv>
 
-Permission to use, copy, modify, and/or distribute this software for any purpose
+Permission to use, copy, modify, and distribute this software for any purpose
 with or without fee is hereby granted, provided that the above copyright notice
 and this permission notice appear in all copies.
 


### PR DESCRIPTION
The license in LICENSE.md is not the same as the one in every source
file header.