### PR TITLE
Add newfstatat() syscall to seccomp filter allow list.

### DIFF
--- a/sandbox-seccomp-filter.c
+++ b/sandbox-seccomp-filter.c
@@ -173,6 +173,9 @@ static const struct sock_filter preauth_work[] = {
 	SC_ALLOW(readv),
 	SC_ALLOW(lseek), /* for kutil_openlog logging */
 	SC_ALLOW(fstat), /* for kutil_openlog logging */
+#ifdef __NR_newfstatat
+	SC_ALLOW(newfstatat), /* for kutil_openlog logging */
+#endif
 	SC_ALLOW(write),
 	SC_ALLOW(writev),
 	SC_ALLOW(close),


### PR DESCRIPTION
Seemingly newer versions of glibc call newfstatat(), wrapping
fstatat() and breaking kutil_openlog().

According to `man 2 newfstatat`[0] the employed system call might be
called fstatat64() on some systems, meaning this patch might not fix
all Linux systems.

[0] https://man.archlinux.org/man/newfstatat.2.en

This fixes #92 on my system.