### PR TITLE
Allow LDFLAGS for kfcgi target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -372,7 +372,7 @@ compats.o: config.h
 # The FastCGI manager is pretty standalone.
 
 kfcgi: kfcgi.o compats.o
-	$(CC) $(CFLAGS) -o $@ kfcgi.o compats.o $(LDADD_LIB_SOCKET)
+	$(CC) $(CFLAGS) -o $@ kfcgi.o compats.o $(LDADD_LIB_SOCKET) $(LDFLAGS)
 
 kfcgi.o: config.h
 


### PR DESCRIPTION
For Linux users, override CFLAGS/LDFLAGS at configure step to avoid pulling compat code breaks for kfcgi because `LDFLAGS` isn't used in the Makefile:

```
$ CFLAGS=`pkg-config --cflags libbsd-overlay` ./configure LDFLAGS=`pkg-config --libs libbsd-overlay`
[...]
$ bmake
cc -isystem /usr/include/bsd -DLIBBSD_OVERLAY -g -W -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes -Wwrite-strings -Wno-unused-parameter  -c kfcgi.c
cc -isystem /usr/include/bsd -DLIBBSD_OVERLAY -g -W -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes -Wwrite-strings -Wno-unused-parameter  -c compats.c
cc -isystem /usr/include/bsd -DLIBBSD_OVERLAY -g -W -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes -Wwrite-strings -Wno-unused-parameter -o kfcgi kfcgi.o compats.o 
/usr/bin/ld: kfcgi.o: in function `main':
/home/markand/downloads/kcgi-0.13.0/kfcgi.c:918: undefined reference to `strtonum'
/usr/bin/ld: /home/markand/downloads/kcgi-0.13.0/kfcgi.c:925: undefined reference to `strtonum'
/usr/bin/ld: /home/markand/downloads/kcgi-0.13.0/kfcgi.c:933: undefined reference to `strtonum'
/usr/bin/ld: /home/markand/downloads/kcgi-0.13.0/kfcgi.c:961: undefined reference to `strtonum'
/usr/bin/ld: /home/markand/downloads/kcgi-0.13.0/kfcgi.c:914: undefined reference to `bsd_getopt'
/usr/bin/ld: /home/markand/downloads/kcgi-0.13.0/kfcgi.c:1011: undefined reference to `strlcpy'
collect2: error: ld returned 1 exit status
*** Error code 1
```