### PR TITLE
Correct spelling mistake in khttp_parse.3

### DIFF
--- a/man/khttp_parse.3
+++ b/man/khttp_parse.3
@@ -646,7 +646,7 @@ These may be integer in
 .Va i ,
 for a 64-bit signed integer; a string
 .Va s ,
-for a NUL-termianted character string; or a double
+for a NUL-terminated character string; or a double
 .Va d ,
 for a double-precision floating-point number.
 This is intentionally basic because the resulting data must be reliably


### PR DESCRIPTION
This is a very small change to fix a typo I discovered in the khttp_parse man page today.

Thank you for this excellent and well-documented library!